### PR TITLE
Fixed database connection resolution

### DIFF
--- a/src/LiveControl/EloquentDataTable/DataTable.php
+++ b/src/LiveControl/EloquentDataTable/DataTable.php
@@ -234,7 +234,7 @@ class DataTable
             return 'CONCAT(' . implode(', " ", ', $this->getRawColumns($column)) . ')';
         }
 
-        return Model::resolveConnection()->getQueryGrammar()->wrap($column);
+        return $this->builder->getConnection()->getQueryGrammar()->wrap($column);
     }
 
     /**
@@ -242,7 +242,7 @@ class DataTable
      */
     protected function getDatabaseDriver()
     {
-        return Model::resolveConnection()->getDriverName();
+        return $this->builder->getConnection()->getDriverName();
     }
 
     /**
@@ -253,7 +253,7 @@ class DataTable
         $rawSelect = [];
         foreach ($this->columns as $index => $column) {
             if (isset($this->rawColumns[$index])) {
-                $rawSelect[] = $this->rawColumns[$index] . ' as ' . Model::resolveConnection()->getQueryGrammar()->wrap($this->columnNames[$index]);
+                $rawSelect[] = $this->rawColumns[$index] . ' as ' . $this->builder->getConnection()->getQueryGrammar()->wrap($this->columnNames[$index]);
             }
         }
         $this->builder = $this->builder->addSelect(new raw(implode(', ', $rawSelect)));


### PR DESCRIPTION
In some non vanilla scenarios where a model is given a custom value for the attribute `protected $connection`, using `Model::resolveConnection()` would give a `'default'` value, causing an `InvalidArgumentException` to be thrown with the following message:

> Database [default] not configured.

This pull request uses the query `builder` instead to resolve the database connection and fixes this issue.