### PR TITLE
Add support for newer eloquent versions and datatable regex search

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/database": "^5.0|^6.0|^7.0|^8.0|^9.0"
+        "illuminate/database": "^5.7|^6.0|^7.0|^8.0|^9.0"
     },
     "require-dev": {
         "phpspec/phpspec": "~2.1"

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "livecontrol/eloquent-datatable",
+    "name": "schoppax/eloquent-datatable",
     "description": "Eloquent DataTable plugin for server side ajax call handling.",
     "keywords": [
         "eloquent",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/database": "5.*"
+        "illuminate/database": "^5.0|^6.0|^7.0|^8.0|^9.0"
     },
     "require-dev": {
         "phpspec/phpspec": "~2.1"

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/database": "^5.7|^6.0|^7.0|^8.0|^9.0"
+        "illuminate/database": ">=5.7.5"
     },
     "require-dev": {
         "phpspec/phpspec": "~2.1"

--- a/src/LiveControl/EloquentDataTable/DataTable.php
+++ b/src/LiveControl/EloquentDataTable/DataTable.php
@@ -343,9 +343,9 @@ class DataTable
     {
         $method = $aggregate ? 'Having' : 'Where';
         $this->builder = $this->builder->{strtolower($method)}(
-            function ($query) use ($search, $regex) {
+            function ($query) use ($search, $regex, $method) {
                 foreach ($this->columns as $column) {
-                    $query->{"or"$method}(
+                    $query->{"or$method"}(
                         new raw($this->getRawColumnQuery($column)),
                         $regex ? 'rlike' : 'like',
                         $regex ? $search : '%' . $search . '%'

--- a/src/LiveControl/EloquentDataTable/DataTable.php
+++ b/src/LiveControl/EloquentDataTable/DataTable.php
@@ -5,6 +5,7 @@ use Exception;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Expression as raw;
+use Illuminate\Support\Str;
 use LiveControl\EloquentDataTable\VersionTransformers\Version110Transformer;
 use LiveControl\EloquentDataTable\VersionTransformers\VersionTransformerContract;
 
@@ -294,7 +295,7 @@ class DataTable
             $result[] = $value;
         }
 
-        return (! $inForeach ? camel_case(implode('_', $result)) : $result);
+        return (! $inForeach ? Str::camel(implode('_', $result)) : $result);
     }
 
     /**

--- a/src/LiveControl/EloquentDataTable/DataTable.php
+++ b/src/LiveControl/EloquentDataTable/DataTable.php
@@ -5,6 +5,7 @@ use Exception;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Expression as raw;
+use Illuminate\Database\Query\Grammars\Grammar;
 use Illuminate\Support\Str;
 use LiveControl\EloquentDataTable\VersionTransformers\Version110Transformer;
 use LiveControl\EloquentDataTable\VersionTransformers\VersionTransformerContract;
@@ -248,7 +249,8 @@ class DataTable
     protected function getRawColumnQuery($column)
     {
         if ($column instanceof ExpressionWithName) {
-            return $column->getExpression();
+            $gramma = new Grammar();
+            return $column->getExpression()->getValue($gramma);
         }
 
         if (is_array($column)) {

--- a/src/LiveControl/EloquentDataTable/DataTable.php
+++ b/src/LiveControl/EloquentDataTable/DataTable.php
@@ -342,11 +342,12 @@ class DataTable
     protected function addAllFilter($search, $regex, $aggregate)
     {
         $method = $aggregate ? 'Having' : 'Where';
+        $columns = $aggregate ? $this->columnNames : $this->columns;  
         $this->builder = $this->builder->{strtolower($method)}(
-            function ($query) use ($search, $regex, $method) {
-                foreach ($this->columns as $column) {
+            function ($query) use ($search, $regex, $method, $columns, $aggregate) {
+                foreach ($columns as $column) {
                     $query->{"or$method"}(
-                        new raw($this->getRawColumnQuery($column)),
+                      new raw($aggregate ? $column : $this->getRawColumnQuery($column)),
                         $regex ? 'rlike' : 'like',
                         $regex ? $search : '%' . $search . '%'
                     );
@@ -360,12 +361,13 @@ class DataTable
      */
     protected function addColumnFilters($aggregate)
     {
-        foreach ($this->columns as $i => $column) {
+        $columns = $aggregate ? $this->columnNames : $this->columns;
+        foreach ($columns as $i => $column) {
             if (static::$versionTransformer->isColumnSearched($i)) {
                 $regex = static::$versionTransformer->isColumnSearchRegex($i);
                 $method = $aggregate ? 'having' : 'where';
                 $this->builder->{$method}(
-                    new raw($this->getRawColumnQuery($column)),
+                    new raw($aggregate ? $column : $this->getRawColumnQuery($column)),
                     $regex ? 'rlike' : 'like',
                     $regex ? static::$versionTransformer->getColumnSearchValue($i) : '%' . static::$versionTransformer->getColumnSearchValue($i) . '%'
                 );

--- a/src/LiveControl/EloquentDataTable/VersionTransformers/Version109Transformer.php
+++ b/src/LiveControl/EloquentDataTable/VersionTransformers/Version109Transformer.php
@@ -13,43 +13,43 @@ class Version109Transformer implements VersionTransformerContract
 
     ];
 
-    public function transform($name)
+    public function transform($name): string
     {
         return (isset($this->translate[$name]) ? $this->translate[$name] : $name);
     }
 
-    public function isSearchRegex()
+    public function isSearchRegex(): bool
     {
         return false;
     }
-    public function getSearchValue()
+    public function getSearchValue(): string
     {
         if(isset($_POST['sSearch']))
             return $_POST['sSearch'];
         return '';
     }
 
-    public function isColumnSearched($i)
+    public function isColumnSearched($i): bool
     {
         return (isset($_POST['bSearchable_' . $i]) && $_POST['bSearchable_' . $i] == 'true' && $_POST['sSearch_' . $i] != '');
     }
 
-    public function isColumnSearchRegex($columnIndex)
+    public function isColumnSearchRegex($columnIndex): bool
     {
         return false;
     }
 
-    public function getColumnSearchValue($i)
+    public function getColumnSearchValue($i): string
     {
         return $_POST['sSearch_' . $i];
     }
 
-    public function isOrdered()
+    public function isOrdered(): bool
     {
         return isset($_POST['iSortCol_0']);
     }
 
-    public function getOrderedColumns()
+    public function getOrderedColumns(): array
     {
         $columns = [];
         for ($i = 0; $i < (int) $_POST['iSortingCols']; $i ++) {

--- a/src/LiveControl/EloquentDataTable/VersionTransformers/Version109Transformer.php
+++ b/src/LiveControl/EloquentDataTable/VersionTransformers/Version109Transformer.php
@@ -18,6 +18,10 @@ class Version109Transformer implements VersionTransformerContract
         return (isset($this->translate[$name]) ? $this->translate[$name] : $name);
     }
 
+    public function isSearchRegex()
+    {
+        return false;
+    }
     public function getSearchValue()
     {
         if(isset($_POST['sSearch']))
@@ -28,6 +32,11 @@ class Version109Transformer implements VersionTransformerContract
     public function isColumnSearched($i)
     {
         return (isset($_POST['bSearchable_' . $i]) && $_POST['bSearchable_' . $i] == 'true' && $_POST['sSearch_' . $i] != '');
+    }
+
+    public function isColumnSearchRegex($columnIndex)
+    {
+        return false;
     }
 
     public function getColumnSearchValue($i)

--- a/src/LiveControl/EloquentDataTable/VersionTransformers/Version110Transformer.php
+++ b/src/LiveControl/EloquentDataTable/VersionTransformers/Version110Transformer.php
@@ -8,6 +8,13 @@ class Version110Transformer implements VersionTransformerContract
         return $name; // we use the same as the requested name
     }
 
+    public function isSearchRegex()
+    {
+        if(isset($_POST['search']) && isset($_POST['search']['regex']))
+            return $_POST['search']['regex'];
+        return false;
+    }
+
     public function getSearchValue()
     {
         if(isset($_POST['search']) && isset($_POST['search']['value']))
@@ -28,6 +35,11 @@ class Version110Transformer implements VersionTransformerContract
             &&
             $_POST['columns'][$columnIndex]['search']['value'] != ''
         );
+    }
+
+    public function isColumnSearchRegex($columnIndex)
+    {
+        return $_POST['columns'][$columnIndex]['search']['regex'];
     }
 
     public function getColumnSearchValue($columnIndex)

--- a/src/LiveControl/EloquentDataTable/VersionTransformers/Version110Transformer.php
+++ b/src/LiveControl/EloquentDataTable/VersionTransformers/Version110Transformer.php
@@ -3,26 +3,26 @@ namespace LiveControl\EloquentDataTable\VersionTransformers;
 
 class Version110Transformer implements VersionTransformerContract
 {
-    public function transform($name)
+    public function transform($name): string
     {
         return $name; // we use the same as the requested name
     }
 
-    public function isSearchRegex()
+    public function isSearchRegex(): bool
     {
         if(isset($_POST['search']) && isset($_POST['search']['regex']))
-            return $_POST['search']['regex'];
+            return filter_var($_POST['search']['regex'], FILTER_VALIDATE_BOOLEAN);
         return false;
     }
 
-    public function getSearchValue()
+    public function getSearchValue(): string
     {
         if(isset($_POST['search']) && isset($_POST['search']['value']))
             return $_POST['search']['value'];
         return '';
     }
 
-    public function isColumnSearched($columnIndex)
+    public function isColumnSearched($columnIndex): bool
     {
         return (
             isset($_POST['columns'])
@@ -37,22 +37,24 @@ class Version110Transformer implements VersionTransformerContract
         );
     }
 
-    public function isColumnSearchRegex($columnIndex)
+    public function isColumnSearchRegex($columnIndex): bool
     {
-        return $_POST['columns'][$columnIndex]['search']['regex'];
+        if (isset($_POST['columns'][$columnIndex]['search']['regex']))
+            return filter_var($_POST['columns'][$columnIndex]['search']['regex'], FILTER_VALIDATE_BOOLEAN);
+        return false;
     }
 
-    public function getColumnSearchValue($columnIndex)
+    public function getColumnSearchValue($columnIndex): string
     {
         return $_POST['columns'][$columnIndex]['search']['value'];
     }
 
-    public function isOrdered()
+    public function isOrdered(): bool
     {
         return (isset($_POST['order']) && isset($_POST['order'][0]));
     }
 
-    public function getOrderedColumns()
+    public function getOrderedColumns(): array
     {
         $columns = [];
         foreach($_POST['order'] as $i => $order)

--- a/src/LiveControl/EloquentDataTable/VersionTransformers/VersionTransformerContract.php
+++ b/src/LiveControl/EloquentDataTable/VersionTransformers/VersionTransformerContract.php
@@ -3,16 +3,16 @@ namespace LiveControl\EloquentDataTable\VersionTransformers;
 
 interface VersionTransformerContract
 {
-    public function transform($name);
+    public function transform($name): string;
 
-    public function isSearchRegex();
-    public function getSearchValue();
+    public function isSearchRegex(): bool;
+    public function getSearchValue(): string;
 
-    public function isColumnSearched($columnIndex);
-    public function isColumnSearchRegex($columnIndex);
-    public function getColumnSearchValue($columnIndex);
+    public function isColumnSearched($columnIndex): bool;
+    public function isColumnSearchRegex($columnIndex): bool;
+    public function getColumnSearchValue($columnIndex): string;
 
 
-    public function isOrdered();
-    public function getOrderedColumns();
+    public function isOrdered(): bool;
+    public function getOrderedColumns(): array;
 }

--- a/src/LiveControl/EloquentDataTable/VersionTransformers/VersionTransformerContract.php
+++ b/src/LiveControl/EloquentDataTable/VersionTransformers/VersionTransformerContract.php
@@ -5,9 +5,11 @@ interface VersionTransformerContract
 {
     public function transform($name);
 
+    public function isSearchRegex();
     public function getSearchValue();
 
     public function isColumnSearched($columnIndex);
+    public function isColumnSearchRegex($columnIndex);
     public function getColumnSearchValue($columnIndex);
 
 


### PR DESCRIPTION
Hi,

this PR changes the following things:
1. Add compatibility to newer eloquent versions.
2. New constructor param to distinguish between orderd columns. This allows you to define columns to be not sortable.
3. Support for regex search pattern supported by mysql / mariadb [rlike operator](https://www.geeksforgeeks.org/rlike-operator-in-mysql/).